### PR TITLE
Update OpenCascade to v7.7.2

### DIFF
--- a/org.librepcb.LibrePCB.yaml
+++ b/org.librepcb.LibrePCB.yaml
@@ -40,8 +40,8 @@ modules:
   - -DUSE_VTK=0
   sources:
   - type: archive
-    url: https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_7_0.tar.gz
-    sha256: 4cadb6d0a9e92dbb1a4eeb48d497b009d8138ffde64f2468d4a1c3f10a052722
+    url: https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_7_2.tar.gz
+    sha256: 0b3cce50b859cd2ed6809fab0de2eb8c8424768bdb6307834766bad0b583605b
     x-checker-data:
       type: anitya
       project-id: 16221


### PR DESCRIPTION
This is a version we know to be working fine. V7.8.0 is broken and V7.8.1 was just released so we don't know yet if it works properly.