### PR TITLE
Add cleanup property

### DIFF
--- a/org.librepcb.LibrePCB.yaml
+++ b/org.librepcb.LibrePCB.yaml
@@ -11,6 +11,9 @@ finish-args:
 - --device=dri
 - --share=network
 - --filesystem=home
+cleanup:
+- /include
+- /lib/cmake
 modules:
 - shared-modules/glu/glu-9.json
 


### PR DESCRIPTION
Just /include makes up 20.8 MB out of 69.5 MB in total

![image](https://github.com/flathub/org.librepcb.LibrePCB/assets/3226457/f7e63488-76f4-4dfa-ba99-3497dd481f2f)
