### PR TITLE
Disable building of OCCT documentation

### DIFF
--- a/org.librepcb.LibrePCB.yaml
+++ b/org.librepcb.LibrePCB.yaml
@@ -21,6 +21,7 @@ modules:
   - -DCMAKE_BUILD_TYPE=Release
   - -DINSTALL_DIR=/app
   - -DBUILD_LIBRARY_TYPE=Shared
+  - -DBUILD_DOC_Overview=0
   - -DBUILD_MODULE_ApplicationFramework=0
   - -DBUILD_MODULE_DataExchange=1
   - -DBUILD_MODULE_Draw=0


### PR DESCRIPTION
Just saw in the build logs some Doxygen documentation is built, which makes no sense for deploying the Flatpak and just wastes time.