### PR TITLE
Disable automatic PRs for updating OCCT

### DIFF
--- a/org.librepcb.LibrePCB.yaml
+++ b/org.librepcb.LibrePCB.yaml
@@ -46,10 +46,9 @@ modules:
   - type: archive
     url: https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_7_2.tar.gz
     sha256: 0b3cce50b859cd2ed6809fab0de2eb8c8424768bdb6307834766bad0b583605b
-    x-checker-data:
-      type: anitya
-      project-id: 16221
-      url-template: https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V${major}_${minor}_$patch.tar.gz
+    # x-checker-data:
+    #  No auto update because we want a specific version of OCCT which is
+    #  known to be working well for us and is in sync with our other releases.
 
 - name: librepcb
   buildsystem: cmake-ninja


### PR DESCRIPTION
As explained in https://github.com/flathub/org.librepcb.LibrePCB/pull/26#issuecomment-2183499926, it makes more sense to deploy LibrePCB with a version of OCCT which is known to be working well (and ideally is in sync with our other deployment methods) than always using the latest version. Thus the update checker makes no sense and is really annoying with the many PRs it creates (#18, #21, #25, #29).

@Alexander-Wilms do you agree with that? Or what do you think?